### PR TITLE
feature: add footer menu

### DIFF
--- a/apps/nextjs/components/Footer.tsx
+++ b/apps/nextjs/components/Footer.tsx
@@ -1,12 +1,29 @@
-import {SettingsFields} from '~/lib/types'
+import {MenuFields, MenuItemFields, SettingsFields} from '~/lib/types'
+import Link from "next/link";
+
+export interface FooterProps {
+  menu: MenuFields
+  settings: SettingsFields
+}
 
 /**
  * Footer component.
  */
-export default function Footer(props: SettingsFields) {
+export default function Footer({settings, menu}: FooterProps) {
   return (
     <footer className="border-t-2 pt-8 text-center lg:text-base">
-      &copy; {new Date().getFullYear()} - {props?.title} - {props?.description}
+      <ul className="flex justify-center space-x-4 lg:m-0">
+        {menu?.menuItems?.nodes?.map(
+          (menu: MenuItemFields, index: number) => (
+            <li className="list-none pb-4  leading-none lg:m-0" key={index}>
+              <Link href={menu?.path}>
+                <a className="lg:text-lg">{menu?.label}</a>
+              </Link>
+            </li>
+          )
+        )}
+      </ul>
+      &copy; {new Date().getFullYear()} - {settings?.title} - {settings?.description}
     </footer>
   )
 }

--- a/apps/nextjs/components/Layout.tsx
+++ b/apps/nextjs/components/Layout.tsx
@@ -7,6 +7,7 @@ import {MenuFields, SettingsFields} from '~/lib/types'
 export interface LayoutProps {
   children: any
   menu: MenuFields
+  footerMenu?: MenuFields
   settings: SettingsFields
   seo: {
     fullHead: string
@@ -19,7 +20,7 @@ export interface LayoutProps {
 /**
  * Layout component.
  */
-export default function Layout({settings, menu, seo, children}: LayoutProps) {
+export default function Layout({settings, menu, footerMenu, seo, children}: LayoutProps) {
   return (
     <div className="prose prose-stone dark:prose-invert lg:prose-xl container m-auto my-8 space-y-16">
       <Head>
@@ -38,7 +39,7 @@ export default function Layout({settings, menu, seo, children}: LayoutProps) {
       </Head>
       <Header settings={settings} menu={menu} />
       <main>{children}</main>
-      <Footer {...settings} />
+      <Footer settings={settings} menu={footerMenu}/>
     </div>
   )
 }

--- a/apps/nextjs/lib/queries.ts
+++ b/apps/nextjs/lib/queries.ts
@@ -22,6 +22,18 @@ export const MENU_FRAGMENT = gql`
   }
 `
 
+export const FOOTER_MENU_FRAGMENT = gql`
+  fragment FooterMenuItems on Menu {
+    menuItems {
+      nodes {
+        path
+        target
+        label
+      }
+    }
+  }
+`
+
 export const FEATURED_IMAGE_FRAGMENT = gql`
   fragment FeaturedImageFields on NodeWithFeaturedImageToMediaItemConnectionEdge {
     node {
@@ -92,6 +104,7 @@ export const GET_ALL_BOOKS = gql`
 export const SINGLE_PAGE_QUERY = gql`
   ${FEATURED_IMAGE_FRAGMENT}
   ${GENERAL_FRAGMENT}
+  ${FOOTER_MENU_FRAGMENT}
   ${MENU_FRAGMENT}
   query SinglePageQuery($slug: ID!) {
     generalSettings {
@@ -99,6 +112,9 @@ export const SINGLE_PAGE_QUERY = gql`
     }
     menu(id: "Header", idType: NAME) {
       ...MenuItems
+    }
+    footerMenu: menu(id: "Footer", idType: NAME) {
+      ...FooterMenuItems
     }
     page(id: $slug, idType: URI) {
       title(format: RENDERED)
@@ -122,12 +138,16 @@ export const SINGLE_POST_QUERY = gql`
   ${FEATURED_IMAGE_FRAGMENT}
   ${GENERAL_FRAGMENT}
   ${MENU_FRAGMENT}
+  ${FOOTER_MENU_FRAGMENT}
   query SinglePostQuery($slug: ID!) {
     generalSettings {
       ...Settings
     }
     menu(id: "Header", idType: NAME) {
       ...MenuItems
+    }
+    footerMenu: menu(id: "Footer", idType: NAME) {
+      ...FooterMenuItems
     }
     post(id: $slug, idType: URI) {
       author {
@@ -190,12 +210,16 @@ export const SINGLE_BOOK_QUERY = gql`
   ${FEATURED_IMAGE_FRAGMENT}
   ${GENERAL_FRAGMENT}
   ${MENU_FRAGMENT}
+  ${FOOTER_MENU_FRAGMENT}
   query SingleBookQuery($slug: ID!) {
     generalSettings {
       ...Settings
     }
     menu(id: "Header", idType: NAME) {
       ...MenuItems
+    }
+    footerMenu: menu(id: "Footer", idType: NAME) {
+      ...FooterMenuItems
     }
     book(id: $slug, idType: URI) {
       title(format: RENDERED)
@@ -222,12 +246,16 @@ export const POSTS_ARCHIVE_QUERY = gql`
   ${FEATURED_IMAGE_FRAGMENT}
   ${GENERAL_FRAGMENT}
   ${MENU_FRAGMENT}
+  ${FOOTER_MENU_FRAGMENT}
   query PostArchiveQuery($category: String!) {
     generalSettings {
       ...Settings
     }
     menu(id: "Header", idType: NAME) {
       ...MenuItems
+    }
+    footerMenu: menu(id: "Footer", idType: NAME) {
+      ...FooterMenuItems
     }
     posts(where: {categoryName: $category}) {
       nodes {
@@ -259,11 +287,15 @@ export const BOOKS_ARCHIVE_QUERY = gql`
   ${FEATURED_IMAGE_FRAGMENT}
   ${GENERAL_FRAGMENT}
   ${MENU_FRAGMENT}
+  ${FOOTER_MENU_FRAGMENT}
   query BookArchiveQuery {
     generalSettings {
       ...Settings
     }
     menu(id: "Header", idType: NAME) {
+      ...MenuItems
+    }
+    footerMenu: menu(id: "Footer", idType: NAME) {
       ...MenuItems
     }
     books {

--- a/apps/nextjs/lib/types.d.ts
+++ b/apps/nextjs/lib/types.d.ts
@@ -5,6 +5,7 @@ export interface PageProps {
     book?: ContentFields
     generalSettings: SettingsFields
     menu: MenuFields
+    footerMenu?: MenuFields
     page?: ContentFields
     post?: ContentFields
     posts?: ArchiveFields

--- a/apps/nextjs/pages/[...slug].tsx
+++ b/apps/nextjs/pages/[...slug].tsx
@@ -31,6 +31,7 @@ export default function GenericPage({data}: PageProps) {
     <Layout
       settings={data?.generalSettings}
       menu={data?.menu}
+      footerMenu={data?.footerMenu}
       seo={data?.page?.seo}
     >
       {
@@ -131,6 +132,7 @@ export const getStaticProps: GetStaticProps = async ({params}) => {
   data = {
     generalSettings: data.generalSettings,
     menu: data.menu,
+    footerMenu: data.footerMenu,
     page: data.books || data.page || data.posts
   }
 

--- a/apps/nextjs/pages/[year]/[month]/[day]/[slug].tsx
+++ b/apps/nextjs/pages/[year]/[month]/[day]/[slug].tsx
@@ -16,6 +16,7 @@ export default function SinglePost({data}: PageProps) {
     <Layout
       settings={data?.generalSettings}
       menu={data?.menu}
+      footerMenu={data?.footerMenu}
       seo={data?.post?.seo}
     >
       <Article content={data?.post} />

--- a/apps/nextjs/pages/book/[slug].tsx
+++ b/apps/nextjs/pages/book/[slug].tsx
@@ -15,6 +15,7 @@ export default function SingleBook({data}: PageProps) {
     <Layout
       settings={data?.generalSettings}
       menu={data?.menu}
+      footerMenu={data?.footerMenu}
       seo={data?.book?.seo}
     >
       <Article content={data?.page} />
@@ -75,6 +76,7 @@ export const getStaticProps: GetStaticProps = async ({params}) => {
   data = {
     generalSettings: data.generalSettings,
     menu: data.menu,
+    footerMenu: data.footerMenu,
     page: data.book
   }
 

--- a/apps/nextjs/pages/index.tsx
+++ b/apps/nextjs/pages/index.tsx
@@ -12,13 +12,17 @@ import {PageProps} from '~/lib/types'
  */
 export default function HomePage({data}: PageProps) {
   return (
-    <Layout
-      settings={data?.generalSettings}
-      menu={data?.menu}
-      seo={data?.page?.seo}
-    >
-      <Article content={data?.page} />
-    </Layout>
+    <>
+      <Layout
+        settings={data?.generalSettings}
+        menu={data?.menu}
+        footerMenu={data?.footerMenu}
+        seo={data?.page?.seo}
+      >
+        <Article content={data?.page} />
+      </Layout>
+    </>
+
   )
 }
 

--- a/apps/nextjs/pages/preview.tsx
+++ b/apps/nextjs/pages/preview.tsx
@@ -12,6 +12,7 @@ export default function Preview({data}) {
     <Layout
       settings={data?.generalSettings}
       menu={data?.menu}
+      footerMenu={data?.footerMenu}
       seo={data?.post?.seo}
     >
       <Article content={data.contentNode} />

--- a/apps/wordpress/setup.sh
+++ b/apps/wordpress/setup.sh
@@ -19,6 +19,8 @@ wp menu create "Header"
 wp menu item add-post header 2
 wp menu item add-post header 5
 wp menu location assign header header-menu
+wp menu create "Footer"
+wp menu location assign footer footer-menu
 wp rewrite structure "/%year%/%monthnum%/%day%/%postname%/"
 echo -e "\e[32m\e[1mSuccess:\e[0m\e[0m WordPress setup complete!"
 sleep 2


### PR DESCRIPTION
Closes #
https://github.com/gregrickaby/nextjs-wordpress/issues/25

### Description

A user can now add links to a footer from content added in WordPress.

### Screenshot

Footer on home page
<img width="1041" alt="nextjs-wordpress-issue-25-home-page" src="https://user-images.githubusercontent.com/44982724/194383051-4779683f-f1ac-4efd-88f1-56ccffb9115a.png">

Footer in blog page
<img width="1042" alt="nextjs-wordpress-issue-25-blog-page" src="https://user-images.githubusercontent.com/44982724/194383062-32132bb4-4892-4ce4-9502-eff27ddecee7.png">

Footer on sample page
<img width="1037" alt="nextjs-wordpress-issue-25-sample-page" src="https://user-images.githubusercontent.com/44982724/194383059-2eb37378-0915-4a11-8ea5-3f09b186d764.png">
### Verification

How will a code reviewer test this?

i) **Create a new menu inside of WordPress.**

1. Log into WordPress 
2. Navigate to Appearance > Menus
3. Click `create a new menu`
4. Enter  the word `Footer` inside the `Menu Name` input field
5. Click the `Create Menu` button.
6.  Populate the menu by selecting any number of pages. Make sure to click the `Add to Menu` button to finalise this. 
7.  Finally, click the `Save Menu` button.

ii) **Run the application locally to see the contents of menu appear inside the footer of each page.**
