### PR TITLE
Fix/#40 header menu

### DIFF
--- a/apps/nextjs/components/Header.tsx
+++ b/apps/nextjs/components/Header.tsx
@@ -37,7 +37,7 @@ const useStyles = createStyles((theme) => ({
     borderTopWidth: 0,
     overflow: 'hidden',
 
-    [theme.fn.largerThan('sm')]: {
+    [theme.fn.largerThan('md')]: {
       display: 'none',
     },
   },


### PR DESCRIPTION
Closes #40

### Description
- Updated dropdown media-query value.

### Screenshot
<img width="982" alt="nextjs-wordpress-issue-40-burger-menu" src="https://user-images.githubusercontent.com/44982724/194857939-c863dc70-e0a4-4284-be80-26ad645abe1b.png">


### Verification

How will a code reviewer test this?
-Toggle the menu on all devices where the burger menu can be seen.
