### PR TITLE
Auto install setup - wrong url link and port 80 in use

### DIFF
--- a/apps/wordpress/docker-compose.yml
+++ b/apps/wordpress/docker-compose.yml
@@ -20,7 +20,9 @@ services:
     image: traefik:latest
     restart: always
     ports:
-      - 3000:3000
+      - target: 80 #internal, container
+        published: 81 #external to host
+        mode: host
       - 443:443
       - 8080:8080
     command:
@@ -30,7 +32,7 @@ services:
       - --api.insecure=true
       - --providers.docker=true
       - --providers.docker.exposedbydefault=false
-      - --entrypoints.web.address=:3000
+      - --entrypoints.web.address=:81
       - --entrypoints.websecure.address=:443
       - --entrypoints.websecure.http.tls=true
       - --entrypoints.web.http.redirections.entrypoint.to=websecure
@@ -51,7 +53,7 @@ services:
       - ../../packages/nextjs-wordpress-plugin:/var/www/html/wp-content/plugins/nextjs-wordpress-plugin
       - ../../packages/nextjs-wordpress-theme:/var/www/html/wp-content/themes/nextjs-wordpress-theme
     expose:
-      - 3000
+      - 81
       - 443
     labels:
       - traefik.enable=true
@@ -105,7 +107,7 @@ services:
     depends_on:
       - mysql
     ports:
-      - 8081:3000
+      - 8081:81
     restart: always
     environment:
       PMA_HOST: ${WORDPRESS_DB_HOST}

--- a/apps/wordpress/docker-compose.yml
+++ b/apps/wordpress/docker-compose.yml
@@ -20,7 +20,7 @@ services:
     image: traefik:latest
     restart: always
     ports:
-      - 80:80
+      - 3000:3000
       - 443:443
       - 8080:8080
     command:
@@ -30,7 +30,7 @@ services:
       - --api.insecure=true
       - --providers.docker=true
       - --providers.docker.exposedbydefault=false
-      - --entrypoints.web.address=:80
+      - --entrypoints.web.address=:3000
       - --entrypoints.websecure.address=:443
       - --entrypoints.websecure.http.tls=true
       - --entrypoints.web.http.redirections.entrypoint.to=websecure
@@ -51,7 +51,7 @@ services:
       - ../../packages/nextjs-wordpress-plugin:/var/www/html/wp-content/plugins/nextjs-wordpress-plugin
       - ../../packages/nextjs-wordpress-theme:/var/www/html/wp-content/themes/nextjs-wordpress-theme
     expose:
-      - 80
+      - 3000
       - 443
     labels:
       - traefik.enable=true
@@ -105,7 +105,7 @@ services:
     depends_on:
       - mysql
     ports:
-      - 8081:80
+      - 8081:3000
     restart: always
     environment:
       PMA_HOST: ${WORDPRESS_DB_HOST}

--- a/apps/wordpress/install.sh
+++ b/apps/wordpress/install.sh
@@ -24,7 +24,7 @@ sleep 30
 echo -e "Installation is complete! 🔥"
 sleep 1
 
-echo -e "Visit https://${WORDPRESS_URL}/wp-admin to log into WordPress."
+echo -e "Visit https://${WORDPRESS_URL}/wp-admin/ to log into WordPress."
 echo -e "username: ${WORDPRESS_USERNAME}"
 echo -e "password: ${WORDPRESS_PASSWORD}"
 exit 0

--- a/setup.sh
+++ b/setup.sh
@@ -45,7 +45,7 @@ cd ./apps/wordpress && chmod +x install.sh && ./install.sh
 
 #6 - Import ACF Fields:
 echo -e '\nPlease import ACF Fields:
-         1 - Log into WordPress https://nextjswp.test/wp-admin (admin/password)
+         1 - Log into WordPress https://nextjswp.test/wp-admin/ (admin/password)
          2 - Go to Custom Fields --> Tools --> Import Field Groups
          3 - Click "Choose File"
          4 - Select apps/wordpress/acf-export-post-fields.json


### PR DESCRIPTION
### Description

This changes the port from 80 to 81 in container "nextjs-wordpress-traefik" as I find with some devs it will have port 80 already in use (open to change it to another port if needed) reference [traefik needs port 80](https://community.traefik.io/t/deploy-traefik-in-docker-when-port-80-and-443-are-already-occupied-by-other-serivces-on-docker-host-synology-ds1019/6044/2).
Also the url link in install.sh and setup.sh needed a '/' so i've added that into [https://nextjswp.test/wp-admin/](https://nextjswp.test/wp-admin/)
### Screenshot


https://user-images.githubusercontent.com/5212703/222613018-3255894f-2b35-4c79-8c92-f26527a4265b.mov

<img width="1087" alt="Screen Shot 2023-03-02 at 7 32 56 PM" src="https://user-images.githubusercontent.com/5212703/222613171-a9136710-a17e-49c6-9f89-fcf3a783b057.png">

### Verification

How will a code reviewer test this?

1. Run through the auto install process npm run install
2. Follow the prompts
3. Go to https://nextjswp.test/wp-admin/ that it works
